### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,7 +4,7 @@ Authors
 Workflow was originally developed by Roman Chyla.  It is now being
 developed and maintained by the Invenio collaboration.  You can
 contact us at
-`info@invenio-software.org <mailto:info@invenio-software.org>`_.
+`info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_.
 
 Contributors:
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -82,7 +82,7 @@ Documentation
 Good luck and thanks for using Workflow.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/workflow

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     packages=packages,
     scripts=['bin/run_workflow.py'],
     author='Invenio Collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/workflow',
     keywords=['workflows', 'finite state machine', 'task execution'],
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>